### PR TITLE
Fix Misspellings

### DIFF
--- a/clima/cython/AdiabatClimate.pyx
+++ b/clima/cython/AdiabatClimate.pyx
@@ -780,7 +780,7 @@ cdef class AdiabatClimate:
   property convecting_with_below:
     """ndarray[bool,ndim=1], shape (nz). If True, then the layer below 
     is convecting with the current layer. Index 1 determines if the 
-    first atomspheric layer is convecting with the ground.
+    first atmospheric layer is convecting with the ground.
     """
     def __get__(self):
       cdef int dim1

--- a/examples/EarlyMars.ipynb
+++ b/examples/EarlyMars.ipynb
@@ -5,7 +5,7 @@
    "id": "dd166210",
    "metadata": {},
    "source": [
-    "We know that early Mars had liquid water because today we observe ancient river valleys. This suggests that Mars' atmosphere use to have enough of a greenhouse effect to warm the surface temperature near ~ 273 K. Reserachers have found that a CO2 greenhouse alone can not warm Early Mars to 273 K. Reserachers have therefore considered alternative greenhouse gases. Perhaps the most plausible is a CO2 and H2 greenhouse, warmed largely by CO2-H2 collision induced absorption.\n",
+    "We know that early Mars had liquid water because today we observe ancient river valleys. This suggests that Mars' atmosphere use to have enough of a greenhouse effect to warm the surface temperature near ~ 273 K. Researchers have found that a CO2 greenhouse alone can not warm Early Mars to 273 K. Researchers have therefore considered alternative greenhouse gases. Perhaps the most plausible is a CO2 and H2 greenhouse, warmed largely by CO2-H2 collision induced absorption.\n",
     "\n",
     "The effects of a CO2 and H2 greenhouse were first calculated accurately by [Wordsworth et al. (2017)](https://doi.org/10.1002/2016GL071766). In this notebook, we try to reproduce their calculations."
    ]

--- a/examples/Tutorial_AdiabatClimate.ipynb
+++ b/examples/Tutorial_AdiabatClimate.ipynb
@@ -379,7 +379,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Uncoment and run to see the error\n",
+    "# Uncomment and run to see the error\n",
     "# P_surf = 0.5e6 # dynes/cm^2\n",
     "# c.make_profile_bg_gas(T_surf, P_i, P_surf, bg_gas)"
    ]

--- a/src/adiabat/clima_adiabat.f90
+++ b/src/adiabat/clima_adiabat.f90
@@ -37,7 +37,7 @@ module clima_adiabat
     !> This can be used to parameterize the ice-albedo feedback.
     procedure(temp_dependent_albedo_fcn), nopass, pointer :: albedo_fcn => null()
 
-    !> Function describing how gases disolve in oceans. This allows for multiple oceans, each
+    !> Function describing how gases dissolve in oceans. This allows for multiple oceans, each
     !> made of different condensed volatiles.
     type(OceanFunction), allocatable :: ocean_fcns(:)
     !> A c-ptr which will be passed to each ocean solubility function.
@@ -97,9 +97,9 @@ module clima_adiabat
     integer, private, allocatable :: ind_conv_lower_x(:)
     !> Indicates if a layer is super-saturated
     logical, private, allocatable :: super_saturated(:)
-    !> Another representation of where convection is occuring. If True,
+    !> Another representation of where convection is occurring. If True,
     !> then the layer below is convecting with the current layer. Index 1 determines
-    !> if the first atomspheric layer is convecting with the ground.
+    !> if the first atmospheric layer is convecting with the ground.
     logical, allocatable :: convecting_with_below(:)
     integer, allocatable :: inds_Tx(:)
     real(dp), allocatable :: lapse_rate(:) !! The true lapse rate (dlnT/dlnP)

--- a/src/adiabat/clima_adiabat_dry.f90
+++ b/src/adiabat/clima_adiabat_dry.f90
@@ -20,7 +20,7 @@ module clima_adiabat_dry
     real(dp), pointer :: P_top
     real(dp), pointer :: rtol
     real(dp), pointer :: atol
-    ! Ouput
+    ! Output
     real(dp), pointer :: P(:)
     real(dp), pointer :: z(:)
     real(dp), pointer :: T(:)
@@ -38,7 +38,7 @@ module clima_adiabat_dry
     !> work variables. All dimension (ng)
     real(dp), allocatable :: f_i_cur(:)
 
-    !> This helps us propogate error messages outside of the integration
+    !> This helps us propagate error messages outside of the integration
     character(:), allocatable :: err
 
   end type

--- a/src/adiabat/clima_adiabat_general.f90
+++ b/src/adiabat/clima_adiabat_general.f90
@@ -26,7 +26,7 @@ module clima_adiabat_general
     real(dp), pointer :: T_surf
     real(dp), pointer :: rtol
     real(dp), pointer :: atol
-    !> Ouput
+    !> Output
     real(dp), pointer :: P(:)
     real(dp), pointer :: z(:)
     real(dp), pointer :: T(:)
@@ -65,7 +65,7 @@ module clima_adiabat_general
     real(dp), allocatable :: cp_i_cur(:)
     real(dp), allocatable :: L_i_cur(:)
     
-    !> This helps us propogate error messages outside of the integration
+    !> This helps us propagate error messages outside of the integration
     character(:), allocatable :: err
     
   end type
@@ -294,7 +294,7 @@ contains
       return
     endif
 
-    ! intial conditions
+    ! initial conditions
     u = [d%T_surf, 0.0_dp]
     Pn = d%P_surf
     do

--- a/src/adiabat/clima_adiabat_rc.f90
+++ b/src/adiabat/clima_adiabat_rc.f90
@@ -21,7 +21,7 @@ module clima_adiabat_rc
     real(dp), pointer :: RH(:)
     real(dp), pointer :: rtol
     real(dp), pointer :: atol
-    ! Ouput
+    ! Output
     real(dp), pointer :: P(:)
     real(dp), pointer :: z(:)
     real(dp), pointer :: f_i(:,:)
@@ -68,7 +68,7 @@ module clima_adiabat_rc
     real(dp), allocatable :: cp_i_cur(:)
     real(dp), allocatable :: L_i_cur(:)
 
-    !> This helps us propogate error messages outside of the integration
+    !> This helps us propagate error messages outside of the integration
     character(:), allocatable :: err
 
   end type
@@ -85,7 +85,7 @@ module clima_adiabat_rc
 contains
 
   ! inputs: P_i_surf, T_surf, T in each grid cell, P_top, planet_mass, planet_radius, nz, sp, ocean_fcns
-  !         indexes where convection is occuring
+  !         indexes where convection is occurring
 
   ! outputs: Pressure, mixing ratios, z, lapse rate everywhere
 

--- a/src/adiabat/clima_adiabat_solve.f90
+++ b/src/adiabat/clima_adiabat_solve.f90
@@ -89,7 +89,7 @@ contains
   end subroutine
 
   !> initializes custom mixing ratios
-  subroutine intialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
+  subroutine initialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
     class(AdiabatClimate), intent(inout) :: self
     character(*), optional, intent(in) :: sp_custom(:)
     real(dp), optional, intent(in) :: P_custom(:)
@@ -204,7 +204,7 @@ contains
       return
     endif
 
-    call intialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
+    call initialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
     if (allocated(err)) return
     
     allocate(convecting_with_below_save(self%nz,0))
@@ -895,7 +895,7 @@ contains
   !> a T profile stable to convection, then a layer is radiative. If instead, the step
   !> tends to a T profile unstable to convection, then the layer is convective. The
   !> routine specifically updates self%convecting_with_below, self%n_convecting_zones, 
-  !> self%ind_conv_lower and self%ind_conv_upper. It also updates all atmosphere varibles.
+  !> self%ind_conv_lower and self%ind_conv_upper. It also updates all atmosphere variables.
   subroutine AdiabatClimate_update_convecting_zones(self, P_i_surf, T_in, mode, err)
     use clima_useful, only: linear_solve
     class(AdiabatClimate), intent(inout) :: self

--- a/src/clima_eqns.f90
+++ b/src/clima_eqns.f90
@@ -168,7 +168,7 @@ contains
     
   end function
   
-  ! coppied from Photochem
+  ! copied from Photochem
   pure subroutine vertical_grid(bottom, top, nz, z, dz)
     real(dp), intent(in) :: bottom, top
     integer, intent(in) :: nz

--- a/src/radtran/clima_radtran.f90
+++ b/src/radtran/clima_radtran.f90
@@ -497,7 +497,7 @@ contains
     real(dp), intent(in) :: P(:) !! Array of pressures in dynes/cm^2. Must be decreasing.
     real(dp), intent(in) :: dtau_dz(:,:) !! (size(P),size(wv)), Optical depth per altitude (1/cm).
     real(dp), intent(in) :: w0(:,:) !! (size(P),size(wv)), Single scattering albedo
-    real(dp), intent(in) :: g0(:,:) !! (size(P),size(wv)), Asymetry parameter
+    real(dp), intent(in) :: g0(:,:) !! (size(P),size(wv)), Asymmetry parameter
     character(:), allocatable, intent(out) :: err
 
     call self%op%set_custom_optical_properties(wv, P, dtau_dz, w0, g0, err)

--- a/src/radtran/clima_radtran_twostream.f90
+++ b/src/radtran/clima_radtran_twostream.f90
@@ -89,7 +89,7 @@ contains
     Ssfc = Rsfc*direct(nz+1)
       
     ! Coefficients of tridiagonal linear system (Equations 39 - 43)
-    ! Odd coeficients (Equation 41)
+    ! Odd coefficients (Equation 41)
     A(1) = 0.0_dp
     B(1) = e1(1)
     D(1) = -e2(1)
@@ -247,7 +247,7 @@ contains
     endif
       
     ! Coefficients of tridiagonal linear system (Equations 39 - 43)
-    ! Odd coeficients (Equation 41)
+    ! Odd coefficients (Equation 41)
     A(1) = 0.0_dp
     B(1) = e1(1)
     D(1) = -e2(1)

--- a/src/radtran/clima_radtran_types.f90
+++ b/src/radtran/clima_radtran_types.f90
@@ -551,7 +551,7 @@ contains
     integer, intent(in) :: l !! Wavelength index
     real(dp), intent(out) :: tau(:) !! (nz), Optical depth.
     real(dp), intent(out) :: w0(:) !! (nz), Single scattering albedo
-    real(dp), intent(out) :: g0(:) !! (nz), Asymetry parameter
+    real(dp), intent(out) :: g0(:) !! (nz), Asymmetry parameter
 
     integer :: j
 

--- a/src/radtran/clima_radtran_types_create.f90
+++ b/src/radtran/clima_radtran_types_create.f90
@@ -246,7 +246,7 @@ contains
     call read_wavl(filename, channel_type, rtc%wavl, err)
     if (allocated(err)) return
 
-    ! Get indicies
+    ! Get indices
     ind1 = minloc(abs(rtc%wavl(1) - op%wavl), 1)
     ind2 = minloc(abs(rtc%wavl(size(rtc%wavl)) - op%wavl), 1)
     if (size(rtc%wavl) /= size(op%wavl(ind1:ind2))) then
@@ -1079,7 +1079,7 @@ contains
     B = tmp2%get_real("B",error = io_err)
     if (allocated(io_err)) then; err = trim(filename)//trim(io_err%message); return; endif
     
-    ! compute xsection for all lamda
+    ! compute xsection for all lambda
     allocate(xs%xs_0d(size(wavl)-1))
     do i = 1,size(wavl)-1
       xs%xs_0d(i) = rayleigh_vardavas(A, B, Delta, wavl(i))


### PR DESCRIPTION
This PR fixes non-breaking misspellings across the codebase. See <https://github.com/Nicholaswogan/photochem/issues/42> for more details.

There remain some misspellings which are breaking changes which have not been corrected: 

<details>

<img width="533" height="122" alt="Screenshot 2026-05-13 at 13 58 25" src="https://github.com/user-attachments/assets/30596ba4-962b-4f6a-8b27-cf1115406213" />
<img width="302" height="144" alt="Screenshot 2026-05-13 at 13 55 56" src="https://github.com/user-attachments/assets/81c28ab1-6eba-4785-8a28-46fe0e7edf1d" />
<img width="921" height="162" alt="Screenshot 2026-05-13 at 13 58 30" src="https://github.com/user-attachments/assets/73325424-b3a6-4717-84a9-97bb1d2e5a6f" />

</details>