### PR TITLE
Fix non-breaking misspellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Create a `conda` environment with all dependencies
 conda create -n clima -c conda-forge python numpy scipy pyyaml scikit-build cython h5py
 ```
 
-Clone this Gitub repository: 
+Clone this GitHub repository:
 
 ```sh
 git clone --depth=1 --recursive https://github.com/Nicholaswogan/clima.git

--- a/clima/cython/AdiabatClimate.pyx
+++ b/clima/cython/AdiabatClimate.pyx
@@ -446,7 +446,7 @@ cdef class AdiabatClimate:
         An array describing a guess for the radiative vs. convective 
         regions of the atmosphere
     custom_dry_mix : dict of {str: ndarray[double,ndim=1]}, optional
-        Allows the user to specify vertically inhomogenous mixing ratios for dry species. 
+        Allows the user to specify vertically inhomogeneous mixing ratios for dry species.
         The dictionary must contain a "pressure" key specifying a pressure grid in dynes/cm^2.
         The other keys are mixing ratio profiles for dry species at each pressure point. 
         The total custom surface pressure is determined by:
@@ -780,7 +780,7 @@ cdef class AdiabatClimate:
   property convecting_with_below:
     """ndarray[bool,ndim=1], shape (nz). If True, then the layer below 
     is convecting with the current layer. Index 1 determines if the 
-    first atomspheric layer is convecting with the ground.
+    first atmospheric layer is convecting with the ground.
     """
     def __get__(self):
       cdef int dim1

--- a/src/adiabat/clima_adiabat.f90
+++ b/src/adiabat/clima_adiabat.f90
@@ -37,7 +37,7 @@ module clima_adiabat
     !> This can be used to parameterize the ice-albedo feedback.
     procedure(temp_dependent_albedo_fcn), nopass, pointer :: albedo_fcn => null()
 
-    !> Function describing how gases disolve in oceans. This allows for multiple oceans, each
+    !> Function describing how gases dissolve in oceans. This allows for multiple oceans, each
     !> made of different condensed volatiles.
     type(OceanFunction), allocatable :: ocean_fcns(:)
     !> A c-ptr which will be passed to each ocean solubility function.
@@ -97,9 +97,9 @@ module clima_adiabat
     integer, private, allocatable :: ind_conv_lower_x(:)
     !> Indicates if a layer is super-saturated
     logical, private, allocatable :: super_saturated(:)
-    !> Another representation of where convection is occuring. If True,
+    !> Another representation of where convection is occurring. If True,
     !> then the layer below is convecting with the current layer. Index 1 determines
-    !> if the first atomspheric layer is convecting with the ground.
+    !> if the first atmospheric layer is convecting with the ground.
     logical, allocatable :: convecting_with_below(:)
     integer, allocatable :: inds_Tx(:)
     real(dp), allocatable :: lapse_rate(:) !! The true lapse rate (dlnT/dlnP)

--- a/src/adiabat/clima_adiabat_dry.f90
+++ b/src/adiabat/clima_adiabat_dry.f90
@@ -20,7 +20,7 @@ module clima_adiabat_dry
     real(dp), pointer :: P_top
     real(dp), pointer :: rtol
     real(dp), pointer :: atol
-    ! Ouput
+    ! Output
     real(dp), pointer :: P(:)
     real(dp), pointer :: z(:)
     real(dp), pointer :: T(:)
@@ -38,7 +38,7 @@ module clima_adiabat_dry
     !> work variables. All dimension (ng)
     real(dp), allocatable :: f_i_cur(:)
 
-    !> This helps us propogate error messages outside of the integration
+    !> This helps us propagate error messages outside of the integration
     character(:), allocatable :: err
 
   end type

--- a/src/adiabat/clima_adiabat_general.f90
+++ b/src/adiabat/clima_adiabat_general.f90
@@ -26,7 +26,7 @@ module clima_adiabat_general
     real(dp), pointer :: T_surf
     real(dp), pointer :: rtol
     real(dp), pointer :: atol
-    !> Ouput
+    !> Output
     real(dp), pointer :: P(:)
     real(dp), pointer :: z(:)
     real(dp), pointer :: T(:)
@@ -65,7 +65,7 @@ module clima_adiabat_general
     real(dp), allocatable :: cp_i_cur(:)
     real(dp), allocatable :: L_i_cur(:)
     
-    !> This helps us propogate error messages outside of the integration
+    !> This helps us propagate error messages outside of the integration
     character(:), allocatable :: err
     
   end type
@@ -294,7 +294,7 @@ contains
       return
     endif
 
-    ! intial conditions
+    ! initial conditions
     u = [d%T_surf, 0.0_dp]
     Pn = d%P_surf
     do

--- a/src/adiabat/clima_adiabat_rc.f90
+++ b/src/adiabat/clima_adiabat_rc.f90
@@ -21,7 +21,7 @@ module clima_adiabat_rc
     real(dp), pointer :: RH(:)
     real(dp), pointer :: rtol
     real(dp), pointer :: atol
-    ! Ouput
+    ! Output
     real(dp), pointer :: P(:)
     real(dp), pointer :: z(:)
     real(dp), pointer :: f_i(:,:)
@@ -68,7 +68,7 @@ module clima_adiabat_rc
     real(dp), allocatable :: cp_i_cur(:)
     real(dp), allocatable :: L_i_cur(:)
 
-    !> This helps us propogate error messages outside of the integration
+    !> This helps us propagate error messages outside of the integration
     character(:), allocatable :: err
 
   end type
@@ -85,7 +85,7 @@ module clima_adiabat_rc
 contains
 
   ! inputs: P_i_surf, T_surf, T in each grid cell, P_top, planet_mass, planet_radius, nz, sp, ocean_fcns
-  !         indexes where convection is occuring
+  !         indexes where convection is occurring
 
   ! outputs: Pressure, mixing ratios, z, lapse rate everywhere
 

--- a/src/adiabat/clima_adiabat_solve.f90
+++ b/src/adiabat/clima_adiabat_solve.f90
@@ -89,7 +89,7 @@ contains
   end subroutine
 
   !> initializes custom mixing ratios
-  subroutine intialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
+  subroutine initialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
     class(AdiabatClimate), intent(inout) :: self
     character(*), optional, intent(in) :: sp_custom(:)
     real(dp), optional, intent(in) :: P_custom(:)
@@ -204,7 +204,7 @@ contains
       return
     endif
 
-    call intialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
+    call initialize_custom_inputs(self, sp_custom, P_custom, mix_custom, err)
     if (allocated(err)) return
     
     allocate(convecting_with_below_save(self%nz,0))
@@ -815,7 +815,7 @@ contains
       ! Compute jacobian
       jac(:,i) = (dTdt_perturb(:) - dTdt(:))/deltaT
 
-      ! unperturb T
+      ! unperturbed T
       T_perturb(:) = T_in(:)
     enddo
 
@@ -895,7 +895,7 @@ contains
   !> a T profile stable to convection, then a layer is radiative. If instead, the step
   !> tends to a T profile unstable to convection, then the layer is convective. The
   !> routine specifically updates self%convecting_with_below, self%n_convecting_zones, 
-  !> self%ind_conv_lower and self%ind_conv_upper. It also updates all atmosphere varibles.
+  !> self%ind_conv_lower and self%ind_conv_upper. It also updates all atmosphere variables.
   subroutine AdiabatClimate_update_convecting_zones(self, P_i_surf, T_in, mode, err)
     use clima_useful, only: linear_solve
     class(AdiabatClimate), intent(inout) :: self

--- a/src/clima_eqns.f90
+++ b/src/clima_eqns.f90
@@ -168,7 +168,7 @@ contains
     
   end function
   
-  ! coppied from Photochem
+  ! copied from Photochem
   pure subroutine vertical_grid(bottom, top, nz, z, dz)
     real(dp), intent(in) :: bottom, top
     integer, intent(in) :: nz

--- a/src/radtran/clima_radtran.f90
+++ b/src/radtran/clima_radtran.f90
@@ -225,7 +225,7 @@ contains
     real(dp), intent(in) :: T(:) !! (nz) Temperature (K) 
     real(dp), intent(in) :: P(:) !! (nz) Pressure (bars)
     real(dp), intent(in) :: densities(:,:) !! (nz,ng) number density of each 
-                                           !! molecule in each layer (molcules/cm3)
+                                           !! molecule in each layer (molecules/cm3)
     real(dp), optional, target, intent(in) :: pdensities(:,:), radii(:,:)
     logical, optional, intent(in) :: compute_solar
     logical, optional, intent(in) :: compute_opacity
@@ -325,7 +325,7 @@ contains
     real(dp), intent(in) :: T(:) !! (nz) Temperature (K) 
     real(dp), intent(in) :: P(:) !! (nz) Pressure (bars)
     real(dp), intent(in) :: densities(:,:) !! (nz,ng) number density of each 
-                                           !! molecule in each layer (molcules/cm3)
+                                           !! molecule in each layer (molecules/cm3)
     real(dp), intent(in) :: dz(:) !! (nz) thickness of each layer (cm)
     real(dp), optional, target, intent(in) :: pdensities(:,:), radii(:,:) !! (nz,np)
     logical, optional, intent(in) :: compute_solar
@@ -467,7 +467,7 @@ contains
     real(dp), intent(in) :: T(:) !! (nz) Temperature (K) 
     real(dp), intent(in) :: P(:) !! (nz) Pressure (bars)
     real(dp), intent(in) :: densities(:,:) !! (nz,ng) number density of each 
-                                           !! molecule in each layer (molcules/cm3)
+                                           !! molecule in each layer (molecules/cm3)
     real(dp), intent(in) :: dz(:) !! (nz) thickness of each layer (cm)
     character(:), allocatable, intent(out) :: err
     
@@ -497,7 +497,7 @@ contains
     real(dp), intent(in) :: P(:) !! Array of pressures in dynes/cm^2. Must be decreasing.
     real(dp), intent(in) :: dtau_dz(:,:) !! (size(P),size(wv)), Optical depth per altitude (1/cm).
     real(dp), intent(in) :: w0(:,:) !! (size(P),size(wv)), Single scattering albedo
-    real(dp), intent(in) :: g0(:,:) !! (size(P),size(wv)), Asymetry parameter
+    real(dp), intent(in) :: g0(:,:) !! (size(P),size(wv)), Asymmetry parameter
     character(:), allocatable, intent(out) :: err
 
     call self%op%set_custom_optical_properties(wv, P, dtau_dz, w0, g0, err)

--- a/src/radtran/clima_radtran_twostream.f90
+++ b/src/radtran/clima_radtran_twostream.f90
@@ -89,7 +89,7 @@ contains
     Ssfc = Rsfc*direct(nz+1)
       
     ! Coefficients of tridiagonal linear system (Equations 39 - 43)
-    ! Odd coeficients (Equation 41)
+    ! Odd coefficients (Equation 41)
     A(1) = 0.0_dp
     B(1) = e1(1)
     D(1) = -e2(1)
@@ -247,7 +247,7 @@ contains
     endif
       
     ! Coefficients of tridiagonal linear system (Equations 39 - 43)
-    ! Odd coeficients (Equation 41)
+    ! Odd coefficients (Equation 41)
     A(1) = 0.0_dp
     B(1) = e1(1)
     D(1) = -e2(1)

--- a/src/radtran/clima_radtran_types.f90
+++ b/src/radtran/clima_radtran_types.f90
@@ -198,7 +198,7 @@ module clima_radtran_types
     ! end work arrays that are needed for k_RandomOverlapResortRebin
 
     ! work arrays that are only needed for if 
-    ! k_method == k_AdapativeEquivalentExtinction
+    ! k_method == k_AdaptiveEquivalentExtinction
     real(dp), allocatable :: tau_grey(:,:) ! (nz,op%nk)
     real(dp), allocatable :: tau_grey_sum(:) ! (nz)
     integer, allocatable :: ind_major(:) ! (nz)
@@ -551,7 +551,7 @@ contains
     integer, intent(in) :: l !! Wavelength index
     real(dp), intent(out) :: tau(:) !! (nz), Optical depth.
     real(dp), intent(out) :: w0(:) !! (nz), Single scattering albedo
-    real(dp), intent(out) :: g0(:) !! (nz), Asymetry parameter
+    real(dp), intent(out) :: g0(:) !! (nz), Asymmetry parameter
 
     integer :: j
 
@@ -580,7 +580,7 @@ contains
     real(dp), intent(in) :: P(:) !! (nz) Pressure (bars)
     real(dp), intent(in) :: T(:) !! (nz) Temperature (K) 
     real(dp), intent(in) :: densities(:,:) !! (nz,ng) number density of each 
-                                           !! molecule in each layer (molcules/cm3)
+                                           !! molecule in each layer (molecules/cm3)
     real(dp), intent(in) :: dz(:) !! (nz) thickness of each layer (cm)
     real(dp), optional, intent(in) :: pdensities(:,:) !! (nz,np) particles/cm3
     real(dp), optional, intent(in) :: radii(:,:) !! (nz,np) cm

--- a/src/radtran/clima_radtran_types_create.f90
+++ b/src/radtran/clima_radtran_types_create.f90
@@ -246,7 +246,7 @@ contains
     call read_wavl(filename, channel_type, rtc%wavl, err)
     if (allocated(err)) return
 
-    ! Get indicies
+    ! Get indices
     ind1 = minloc(abs(rtc%wavl(1) - op%wavl), 1)
     ind2 = minloc(abs(rtc%wavl(size(rtc%wavl)) - op%wavl), 1)
     if (size(rtc%wavl) /= size(op%wavl(ind1:ind2))) then
@@ -320,7 +320,7 @@ contains
           return
         endif
 
-        ! Make a list of avaliable data files
+        ! Make a list of available data files
         op%nk = j
         if (allocated(tmp_str_list)) deallocate(tmp_str_list)
         allocate(tmp_str_list(op%nk))
@@ -434,7 +434,7 @@ contains
           endif
         enddo
 
-        ! Make a list of avaliable data files
+        ! Make a list of available data files
         op%ncia = j
         if (allocated(cia_list)) deallocate(cia_list)
         allocate(cia_list(op%ncia))
@@ -548,7 +548,7 @@ contains
     if (allocated(sop%photolysis_xs) .or. tmp_bool) then
 
       if (tmp_bool) then
-        ! need to go see what photolysis data is avaliable
+        ! need to go see what photolysis data is available
         j = 0
         do i = 1,size(species_names)
           filename = datadir//"/xsections/"//trim(species_names(i))//".h5"
@@ -903,7 +903,7 @@ contains
     cont%LH2O = ind
 
     if (.not. is_hdf5(filename)) then
-      err = 'Continuum "'//model//'" is not avaliable.'
+      err = 'Continuum "'//model//'" is not available.'
       return
     endif
     
@@ -1079,7 +1079,7 @@ contains
     B = tmp2%get_real("B",error = io_err)
     if (allocated(io_err)) then; err = trim(filename)//trim(io_err%message); return; endif
     
-    ! compute xsection for all lamda
+    ! compute xsection for all lambda
     allocate(xs%xs_0d(size(wavl)-1))
     do i = 1,size(wavl)-1
       xs%xs_0d(i) = rayleigh_vardavas(A, B, Delta, wavl(i))
@@ -1351,7 +1351,7 @@ contains
 
     call h%close()
 
-    ! initalize interpolators
+    ! initialize interpolators
     allocate(k%log10k(k%ngauss,k%nwav))
     do i = 1,k%nwav
       do j = 1,k%ngauss

--- a/templates/AdiabatClimate/Earth/settings.yaml
+++ b/templates/AdiabatClimate/Earth/settings.yaml
@@ -18,7 +18,7 @@ optical-properties:
   # `k-method` is the method for mixing k-distributions. The only option is RandomOverlapResortRebin
   k-method: RandomOverlapResortRebin
 
-  # Here you specify opacites. You can see avaliable opacities by looking in
+  # Here you specify opacities. You can see available opacities by looking in
   # `clima/data/` folder. `CIA`, `rayleigh`, `photolysis-xs` and `water-continuum`
   # are optional. If you omit these keys then these opacities will not be included.
   # `k-distributions` is the only required key. The simplest way to set opacities


### PR DESCRIPTION
Fixes several non-breaking misspellings in comments, documentation strings, README text, and internal error text. Also renames one internal helper from `intialize_custom_inputs` to `initialize_custom_inputs` with its only call site updated.

Validation:
- `git diff --check`

Refs #14